### PR TITLE
Update Dockerfile

### DIFF
--- a/source/kvs_transcribe_streaming_lambda/Dockerfile
+++ b/source/kvs_transcribe_streaming_lambda/Dockerfile
@@ -1,6 +1,6 @@
 # Install dependencies and build jar
 
-FROM gradle:jdk11 as build
+FROM gradle:6.8.3-jdk11 as build
 
 RUN pwd 
 RUN ls -altr


### PR DESCRIPTION
We need to specify the right version of Gradle, otherwise it will break. Using only the "jdk11" to reference the base image is not a best practice, since this can be changed in the future when new Gradle versions are available. I have tested with Gradle version 6.8.3 and was able to get the image built.


*Description of changes:* Changed the Docker Image tag on Dockerfile.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
