### PR TITLE
Use DynamoDB on-demand mode to avoid throttling with concurrent calls

### DIFF
--- a/deployment/ai-powered-speech-analytics-for-amazon-connect.yaml
+++ b/deployment/ai-powered-speech-analytics-for-amazon-connect.yaml
@@ -388,12 +388,7 @@ Resources:
           -
             AttributeName: "StartTime"
             KeyType: "RANGE"
-        # assuming 5 concurrent calls
-        ProvisionedThroughput:
-          ReadCapacityUnits:
-              5
-          WriteCapacityUnits:
-              5
+        BillingMode: "PAY_PER_REQUEST"
         PointInTimeRecoverySpecification:
             PointInTimeRecoveryEnabled: True
         SSESpecification:
@@ -426,12 +421,7 @@ Resources:
             -
               AttributeName: "StartTime"
               KeyType: "RANGE"
-          # assuming 5 concurrent calls
-          ProvisionedThroughput:
-            ReadCapacityUnits:
-              5
-            WriteCapacityUnits:
-              5
+          BillingMode: "PAY_PER_REQUEST"
           PointInTimeRecoverySpecification:
             PointInTimeRecoveryEnabled: True
           SSESpecification:
@@ -458,12 +448,7 @@ Resources:
             -
               AttributeName: "contactId"
               KeyType: "HASH"
-          # assuming 5 concurrent calls
-          ProvisionedThroughput:
-            ReadCapacityUnits:
-                5
-            WriteCapacityUnits:
-                5
+          BillingMode: "PAY_PER_REQUEST"
           PointInTimeRecoverySpecification:
               PointInTimeRecoveryEnabled: True
           SSESpecification:
@@ -967,9 +952,7 @@ Resources:
             KeySchema:
                 - AttributeName: connectionId
                   KeyType: HASH
-            ProvisionedThroughput:
-                ReadCapacityUnits: 5
-                WriteCapacityUnits: 5
+            BillingMode: "PAY_PER_REQUEST"
             PointInTimeRecoverySpecification:
                 PointInTimeRecoveryEnabled: true
             SSESpecification:


### PR DESCRIPTION
*Issue #, if available:*

This commit fixes the issue #33.

*Description of changes:*

The transcription stops if there are too many requests to DynamoDB. This commit changes the billing mode to the on-demand mode to avoid throttling.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
