### PR TITLE
Recreate a FragmentMetadataVisitor object when the KVS connection renewed

### DIFF
--- a/source/kvs_transcribe_streaming_lambda/src/main/java/com/amazonaws/kvstranscribestreaming/KVSRecordingTask.java
+++ b/source/kvs_transcribe_streaming_lambda/src/main/java/com/amazonaws/kvstranscribestreaming/KVSRecordingTask.java
@@ -297,6 +297,11 @@ private KVSStreamTrackObject getKVSStreamTrackObjectAfterTimedOut(String streamN
     StreamingMkvReader streamingMkvReader = StreamingMkvReader.createDefault(new InputStreamParserByteSource(kvsInputStream));
     kvsStreamTrackObject.setInputStream(kvsInputStream);
     kvsStreamTrackObject.setStreamingMkvReader(streamingMkvReader);
+
+    KVSContactTagProcessor tagProcessor = kvsStreamTrackObject.getTagProcessor();
+    FragmentMetadataVisitor fragmentVisitor = FragmentMetadataVisitor.create(Optional.of(tagProcessor));
+    kvsStreamTrackObject.setFragmentVisitor(fragmentVisitor);
+
     return kvsStreamTrackObject;
 }
 

--- a/source/kvs_transcribe_streaming_lambda/src/main/java/com/amazonaws/kvstranscribestreaming/KVSStreamTrackObject.java
+++ b/source/kvs_transcribe_streaming_lambda/src/main/java/com/amazonaws/kvstranscribestreaming/KVSStreamTrackObject.java
@@ -47,6 +47,10 @@ public class KVSStreamTrackObject {
     public FragmentMetadataVisitor getFragmentVisitor() {
         return fragmentVisitor;
     }
+
+    public void setFragmentVisitor(FragmentMetadataVisitor fragmentVisitor) {
+        this.fragmentVisitor = fragmentVisitor;
+    }
  
     public Path getSaveAudioFilePath() {
         return saveAudioFilePath;


### PR DESCRIPTION
*Issue #, if available:*

This commit partially fixes the issue #32.

*Description of changes:*

When the transcription is restarted at 42 minutes, the instance of FragmentMetadataVisitor is not renewed and may throw exceptions due to the seek of the input stream. This commit fixes to recreate the instance when restarting the transcription.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
