### PR TITLE
Save the fragment number of KVS to restart from where the transcription reached

### DIFF
--- a/deployment/ai-powered-speech-analytics-for-amazon-connect.yaml
+++ b/deployment/ai-powered-speech-analytics-for-amazon-connect.yaml
@@ -2204,6 +2204,8 @@ Resources:
                 Value: "FALSE"
               - Name: START_SELECTOR_TYPE
                 Value: "NOW"
+              - Name: START_SELECTOR_TYPE_AFTER_TIMED_OUT
+                Value: "FRAGMENT_NUMBER"
               - Name: TRANSCRIBE_REGION
                 Value: !Ref AWS::Region
               - Name: AWS_REGION

--- a/source/kvs_transcribe_streaming_lambda/src/main/java/com/amazonaws/kvstranscribestreaming/KVSRecordingTask.java
+++ b/source/kvs_transcribe_streaming_lambda/src/main/java/com/amazonaws/kvstranscribestreaming/KVSRecordingTask.java
@@ -80,6 +80,7 @@ public class KVSRecordingTask {
 
     private static final boolean RECORDINGS_PUBLIC_READ_ACL = Boolean.parseBoolean(System.getenv("RECORDINGS_PUBLIC_READ_ACL"));
     private static final String START_SELECTOR_TYPE = System.getenv("START_SELECTOR_TYPE");
+    private static final String START_SELECTOR_TYPE_AFTER_TIMED_OUT = System.getenv("START_SELECTOR_TYPE_AFTER_TIMED_OUT");
 
     private static final String TABLE_CALLER_TRANSCRIPT = System.getenv("TABLE_CALLER_TRANSCRIPT");
     private static final String TABLE_CALLER_TRANSCRIPT_TO_CUSTOMER = System.getenv("TABLE_CALLER_TRANSCRIPT_TO_CUSTOMER");
@@ -279,7 +280,8 @@ private void closeFileAndUploadRawAudio(KVSStreamTrackObject kvsStreamTrackObjec
  */
 private KVSStreamTrackObject getKVSStreamTrackObject(String streamName, String startFragmentNum, String trackName,
     String contactId) throws FileNotFoundException {
-    InputStream kvsInputStream = KVSUtils.getInputStreamFromKVS(streamName, REGION, startFragmentNum, getAWSCredentials(), START_SELECTOR_TYPE);
+    String startSelectorType = startFragmentNum == null ? "NOW" : START_SELECTOR_TYPE;
+    InputStream kvsInputStream = KVSUtils.getInputStreamFromKVS(streamName, REGION, startFragmentNum, getAWSCredentials(), startSelectorType);
     StreamingMkvReader streamingMkvReader = StreamingMkvReader.createDefault(new InputStreamParserByteSource(kvsInputStream));
 
     KVSContactTagProcessor tagProcessor = new KVSContactTagProcessor(contactId);
@@ -293,7 +295,8 @@ private KVSStreamTrackObject getKVSStreamTrackObject(String streamName, String s
 }
 
 private KVSStreamTrackObject getKVSStreamTrackObjectAfterTimedOut(String streamName, String startFragmentNum, KVSStreamTrackObject kvsStreamTrackObject) throws FileNotFoundException {
-    InputStream kvsInputStream = KVSUtils.getInputStreamFromKVS(streamName, REGION, startFragmentNum, getAWSCredentials(), START_SELECTOR_TYPE);
+    String startSelectorType = startFragmentNum == null ? "NOW" : START_SELECTOR_TYPE_AFTER_TIMED_OUT;
+    InputStream kvsInputStream = KVSUtils.getInputStreamFromKVS(streamName, REGION, startFragmentNum, getAWSCredentials(), startSelectorType);
     StreamingMkvReader streamingMkvReader = StreamingMkvReader.createDefault(new InputStreamParserByteSource(kvsInputStream));
     kvsStreamTrackObject.setInputStream(kvsInputStream);
     kvsStreamTrackObject.setStreamingMkvReader(streamingMkvReader);

--- a/source/kvs_transcribe_streaming_lambda/src/main/java/com/amazonaws/kvstranscribestreaming/KVSRecordingTask.java
+++ b/source/kvs_transcribe_streaming_lambda/src/main/java/com/amazonaws/kvstranscribestreaming/KVSRecordingTask.java
@@ -1,5 +1,7 @@
 package com.amazonaws.kvstranscribestreaming;
 
+import com.amazonaws.kinesisvideo.parser.utilities.FragmentMetadata;
+
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.kinesisvideo.parser.ebml.InputStreamParserByteSource;
@@ -154,13 +156,11 @@ public class KVSRecordingTask {
 
         while (isKVSTimedOut) {
             if (isStreamAudioFromCustomerEnabled) {
-                Optional < FragmentMetadata > fragmentMetadata = kvsStreamTrackObjectFromCustomer.getFragmentVisitor().getCurrentFragmentMetadata();
-                String fragmentNumber = fragmentMetadata.get().getFragmentNumberString();
+                String fragmentNumber = kvsStreamTrackObjectFromCustomer.getLastFragmentNumber();
                 getKVSStreamTrackObjectAfterTimedOut(streamName, fragmentNumber, kvsStreamTrackObjectFromCustomer);
              }
             if (isStreamAudioToCustomerEnabled) {
-                Optional < FragmentMetadata > fragmentMetadata = kvsStreamTrackObjectToCustomer.getFragmentVisitor().getCurrentFragmentMetadata();
-                String fragmentNumber = fragmentMetadata.get().getFragmentNumberString();
+                String fragmentNumber = kvsStreamTrackObjectToCustomer.getLastFragmentNumber();
                 getKVSStreamTrackObjectAfterTimedOut(streamName, fragmentNumber, kvsStreamTrackObjectToCustomer);
            }
             isKVSTimedOut = startStreaming(transcribeEnabled, kvsStreamTrackObjectFromCustomer, kvsStreamTrackObjectToCustomer,
@@ -314,7 +314,7 @@ private CompletableFuture < Void > getStartStreamingTranscriptionFuture(KVSStrea
             kvsStreamTrackObject.getTagProcessor(),
             kvsStreamTrackObject.getFragmentVisitor(),
             kvsStreamTrackObject.getTrackName()),
-        new StreamTranscriptionBehaviorImpl(transcribedSegmentWriter, tableName),
+        new StreamTranscriptionBehaviorImpl(transcribedSegmentWriter, tableName, kvsStreamTrackObject),
         channel
     );
 }

--- a/source/kvs_transcribe_streaming_lambda/src/main/java/com/amazonaws/kvstranscribestreaming/KVSStreamTrackObject.java
+++ b/source/kvs_transcribe_streaming_lambda/src/main/java/com/amazonaws/kvstranscribestreaming/KVSStreamTrackObject.java
@@ -2,10 +2,12 @@ package com.amazonaws.kvstranscribestreaming;
  
 import com.amazonaws.kinesisvideo.parser.mkv.StreamingMkvReader;
 import com.amazonaws.kinesisvideo.parser.utilities.FragmentMetadataVisitor;
+import com.amazonaws.kinesisvideo.parser.utilities.FragmentMetadata;
  
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.nio.file.Path;
+import java.util.Optional;
  
 public class KVSStreamTrackObject {
     private InputStream inputStream;
@@ -15,6 +17,7 @@ public class KVSStreamTrackObject {
     private Path saveAudioFilePath;
     private FileOutputStream outputStream;
     private String trackName;
+    private String lastFragmentNumber;
  
     public KVSStreamTrackObject(InputStream inputStream, StreamingMkvReader streamingMkvReader,
                                 KVSContactTagProcessor tagProcessor, FragmentMetadataVisitor fragmentVisitor,
@@ -62,5 +65,17 @@ public class KVSStreamTrackObject {
  
     public String getTrackName() {
         return trackName;
+    }
+
+    public void saveLastFragmentNumber() {
+        Optional<FragmentMetadata> fragmentMetadata = this.fragmentVisitor.getCurrentFragmentMetadata();
+        if (fragmentMetadata.isPresent()) {
+            String fragmentNumber = fragmentMetadata.get().getFragmentNumberString();
+            this.lastFragmentNumber = fragmentNumber;
+        }
+    }
+
+    public String getLastFragmentNumber() {
+        return this.lastFragmentNumber;
     }
 }

--- a/source/kvs_transcribe_streaming_lambda/src/main/java/com/amazonaws/kvstranscribestreaming/KVSTranscribeStreamingLambda.java
+++ b/source/kvs_transcribe_streaming_lambda/src/main/java/com/amazonaws/kvstranscribestreaming/KVSTranscribeStreamingLambda.java
@@ -244,7 +244,7 @@ public class KVSTranscribeStreamingLambda implements RequestHandler<Transcriptio
                     // since we're definitely working with telephony audio, we know that's 8 kHz
                     getRequest(8000, languageCode),
                     new FileAudioStreamPublisher(inputStream),
-                    new StreamTranscriptionBehaviorImpl(fromCustomerSegmentWriter, TABLE_CALLER_TRANSCRIPT),
+                    new StreamTranscriptionBehaviorImpl(fromCustomerSegmentWriter, TABLE_CALLER_TRANSCRIPT, null),
                     "None"
             );
 
@@ -324,7 +324,7 @@ public class KVSTranscribeStreamingLambda implements RequestHandler<Transcriptio
                         kvsStreamTrackObject.getTagProcessor(),
                         kvsStreamTrackObject.getFragmentVisitor(),
                         kvsStreamTrackObject.getTrackName()),
-                new StreamTranscriptionBehaviorImpl(transcribedSegmentWriter, tableName),
+                new StreamTranscriptionBehaviorImpl(transcribedSegmentWriter, tableName, kvsStreamTrackObject),
                 channel
         );
     }

--- a/source/kvs_transcribe_streaming_lambda/src/main/java/com/amazonaws/kvstranscribestreaming/KVSUtils.java
+++ b/source/kvs_transcribe_streaming_lambda/src/main/java/com/amazonaws/kvstranscribestreaming/KVSUtils.java
@@ -181,7 +181,6 @@ public final class KVSUtils {
                                                     String startSelectorType) {
         Validate.notNull(streamName);
         Validate.notNull(region);
-        Validate.notNull(startFragmentNum);
         Validate.notNull(awsCredentialsProvider);
 
         AmazonKinesisVideo amazonKinesisVideo = (AmazonKinesisVideo) AmazonKinesisVideoClientBuilder.standard().build();
@@ -199,6 +198,7 @@ public final class KVSUtils {
         startSelectorType = isNullOrEmpty(startSelectorType) ? "NOW" : startSelectorType;
         switch (startSelectorType) {
             case "FRAGMENT_NUMBER":
+                Validate.notNull(startFragmentNum);
                 startSelector = new StartSelector()
                         .withStartSelectorType(StartSelectorType.FRAGMENT_NUMBER)
                         .withAfterFragmentNumber(startFragmentNum);

--- a/source/kvs_transcribe_streaming_lambda/src/main/java/com/amazonaws/transcribestreaming/StreamTranscriptionBehaviorImpl.java
+++ b/source/kvs_transcribe_streaming_lambda/src/main/java/com/amazonaws/transcribestreaming/StreamTranscriptionBehaviorImpl.java
@@ -1,5 +1,6 @@
 package com.amazonaws.transcribestreaming;
 
+import com.amazonaws.kvstranscribestreaming.KVSStreamTrackObject;
 import com.amazonaws.kvstranscribestreaming.TranscribedSegmentWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,10 +32,12 @@ public class StreamTranscriptionBehaviorImpl implements StreamTranscriptionBehav
     private static final Logger logger = LoggerFactory.getLogger(StreamTranscriptionBehaviorImpl.class);
     private final TranscribedSegmentWriter segmentWriter;
     private final String tableName;
+    private final KVSStreamTrackObject kvsStreamTrackObject;
 
-    public StreamTranscriptionBehaviorImpl(TranscribedSegmentWriter segmentWriter, String tableName) {
+    public StreamTranscriptionBehaviorImpl(TranscribedSegmentWriter segmentWriter, String tableName, KVSStreamTrackObject kvsStreamTrackObject) {
         this.segmentWriter = segmentWriter;
         this.tableName = tableName;
+        this.kvsStreamTrackObject = kvsStreamTrackObject;
     }
 
     @Override
@@ -44,6 +47,11 @@ public class StreamTranscriptionBehaviorImpl implements StreamTranscriptionBehav
 
     @Override
     public void onStream(TranscriptResultStream e) {
+        if (this.kvsStreamTrackObject != null) {
+            // Save the fragment number of KVS to restart from where the transcription has reached.
+            this.kvsStreamTrackObject.saveLastFragmentNumber();
+        }
+
         // EventResultStream has other fields related to the timestamp of the transcripts in it.
         // Please refer to the javadoc of TranscriptResultStream for more details
         segmentWriter.writeToDynamoDB((TranscriptEvent) e, tableName);


### PR DESCRIPTION
*Issue #, if available:*

This commit partially solves the issue #32.

*Description of changes:*

When the transcription restarts, Transcribe may be still consuming the audio input and converting it to the script. The script under transcription may not be converted in the current implementation because the KVS stream restarts from the latest position. This commit saves the fragment number used by Transcribe and restarts the stream from that number.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
