### PR TITLE
Use ECR Public for pulling official images to avoid pull limits

### DIFF
--- a/deployment/ai-powered-speech-analytics-for-amazon-connect.yaml
+++ b/deployment/ai-powered-speech-analytics-for-amazon-connect.yaml
@@ -2240,7 +2240,7 @@ Resources:
             Name: QueueProcessingContainer
           - Cpu: 32
             Essential: false
-            Image: amazon/aws-xray-daemon
+            Image: public.ecr.aws/xray/aws-xray-daemon
             LogConfiguration:
               LogDriver: awslogs
               Options:

--- a/source/kvs_transcribe_streaming_lambda/Dockerfile
+++ b/source/kvs_transcribe_streaming_lambda/Dockerfile
@@ -1,6 +1,6 @@
 # Install dependencies and build jar
 
-FROM gradle:6.8.3-jdk11 as build
+FROM public.ecr.aws/docker/library/gradle:6.8.3-jdk11 as build
 
 RUN pwd 
 RUN ls -altr
@@ -11,7 +11,7 @@ COPY kvs_transcribe_streaming_lambda/build.gradle .
 RUN gradle buildFargate --no-daemon
 
 
-FROM amazoncorretto:11
+FROM public.ecr.aws/amazoncorretto/amazoncorretto:11
 
 WORKDIR /app
 


### PR DESCRIPTION
*Description of changes:*

Pulling the base images from Docker Hub often fails due to the pull limit. This commit changes the source of the images to ECR Public.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
