### PR TITLE
Updating CCP URLs to latest version

### DIFF
--- a/source/web_site/agentAssist.html
+++ b/source/web_site/agentAssist.html
@@ -402,8 +402,8 @@
                 var contactId;
                 var connectionId;
                 var credentials;
-                var loginURL = `https://${instanceAlias}.awsapps.com/connect/login`;
-                var ccpURL = `https://${alias}.awsapps.com/connect/ccp-v2/softphone`;
+                var loginURL = `https://${instanceAlias}.my.connect.aws/login`;
+                var ccpURL = `https://${alias}.my.connect.aws/ccp-v2/softphone`;
                 var loginWindow;
                 var isChat = true;
                 var fromLanguage;


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Previous CCP URLs referred to old Amazon Connect "*.awsapps.com" domains. This issue would cause users to fail to login to Amazon Connect CCP. Unauthorized Domain error.

Updated CCP URLs found in agentAssist.html to latest URLs defined here: https://docs.aws.amazon.com/connect/latest/adminguide/amazon-connect-contact-control-panel.html

*Related Customer Issue*
AWS re:Post: https://repost.aws/questions/QUJz5wb1bpQka0uF_flODucQ/aws-connect-error-application-has-not-been-enabled-for-your-directory

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
